### PR TITLE
Display attached images in HTML emails

### DIFF
--- a/src/AcMailer/Service/MailService.php
+++ b/src/AcMailer/Service/MailService.php
@@ -95,9 +95,11 @@ class MailService implements MailServiceInterface, EventManagerAwareInterface, M
                     continue; // If checked file is not valid, continue to the next
                 }
                 
+                $basename = basename($attachment);
+                
                 $part               = new MimePart(fopen($attachment, 'r'));
-                $part->id	        = $attachment;
-                $part->filename     = basename($attachment);
+                $part->id           = $basename;
+                $part->filename     = $basename;
                 $part->type         = $info->file($attachment);
                 $part->encoding     = Mime::ENCODING_BASE64;
                 $part->disposition  = Mime::DISPOSITION_ATTACHMENT;


### PR DESCRIPTION
Enables embedding of images inside html template
&lt;img src="cid:logo.png" alt="Logo"&gt;

Similar header is added for every attachment and can be used as in above example
Content-ID:&lt;logo.png&gt;
